### PR TITLE
Add banano support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _First, take a look in [JNano Commons](https://github.com/rotilho/jnano-commons)
 **Sample**
 ```java
 NanoAPI nanoAPI = NanoAPI.builder().endpoint("http://my-wallet").build();
-NanoAccountOperations accountOperations = NanoAccountOperations.of(nanoAPI);
+NanoAccountOperations accountOperations = NanoAccountOperations.of(NanoBaseAccountType.NANO, nanoAPI);
 
 Optional<NanoAccountInfo> info = accountOperations.getInfo(account);
 info.ifPresent(i-> log.info(i));
@@ -34,7 +34,7 @@ info.ifPresent(i-> log.info(i));
 NanoAPI workNanoAPI = NanoAPI.builder().endpoint("http://my-wallet").readTimeoutMillis(100_000).build();
 NanoWorkOperations workOperations = NanoRemoteWorkOperations.of(workNanoAPI);
 
-NanoTransactionOperations transactionOperations = NanoTransactionOperations.of(api, accountOperations, workOperations);
+NanoTransactionOperations transactionOperations = NanoTransactionOperations.of(NanoBaseAccountType.NANO, api, accountOperations, workOperations);
 
 List<NanoTransaction<NanoStateBlock>> transactions = transactionOperations.receive(privateKey);
 transactions.forEach(t -> log.info(t));

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'com.rotilho.jnano'
-version '1.0.0'
+version '1.1.0'
 
 sourceCompatibility = 1.8
 
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.rotilho.jnano:jnano-commons:1.4.0-SNAPSHOT'
+    compile 'com.rotilho.jnano:jnano-commons:1.4.1'
     compile 'com.squareup.okhttp3:okhttp:3.11.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
     compile 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.9.7'

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,11 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
-    compile 'com.rotilho.jnano:jnano-commons:1.3.0'
+    compile 'com.rotilho.jnano:jnano-commons:1.4.0-SNAPSHOT'
     compile 'com.squareup.okhttp3:okhttp:3.11.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
     compile 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.9.7'

--- a/src/main/java/com/rotilho/jnano/client/account/NanoAccountOperations.java
+++ b/src/main/java/com/rotilho/jnano/client/account/NanoAccountOperations.java
@@ -12,6 +12,7 @@ import com.rotilho.jnano.client.block.NanoReceiveBlock;
 import com.rotilho.jnano.client.block.NanoSendBlock;
 import com.rotilho.jnano.client.block.NanoStateBlock;
 import com.rotilho.jnano.client.transaction.NanoTransaction;
+import com.rotilho.jnano.commons.NanoAccountType;
 import com.rotilho.jnano.commons.NanoAccounts;
 import com.rotilho.jnano.commons.NanoAmount;
 
@@ -31,6 +32,8 @@ import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor(staticName = "of")
 public class NanoAccountOperations {
+    @NonNull
+    private final NanoAccountType accountType;
     @NonNull
     private final NanoAPI api;
 
@@ -79,7 +82,7 @@ public class NanoAccountOperations {
 
         AccountHistory history = api.execute(action, AccountHistory.class);
         return history.getHistory().stream()
-                .map(a -> a.toTransaction(account))
+                .map(a -> a.toTransaction(accountType, account))
                 .collect(toList());
     }
 
@@ -151,8 +154,8 @@ public class NanoAccountOperations {
         /**
          * The account field returned by the node is the sender account not the requested account
          */
-        private NanoTransaction<?> toTransaction(String account) {
-            NanoBlock block = toBlock(account);
+        private NanoTransaction<?> toTransaction(NanoAccountType accountType, String account) {
+            NanoBlock block = toBlock(accountType, account);
             return NanoTransaction.builder()
                     .block(block)
                     .signature(signature)
@@ -160,10 +163,11 @@ public class NanoAccountOperations {
                     .build();
         }
 
-        private NanoBlock toBlock(String account) {
+        private NanoBlock toBlock(NanoAccountType accountType, String account) {
             switch (type) {
                 case "open":
                     return NanoOpenBlock.builder()
+                            .accountType(accountType)
                             .source(source)
                             .representative(representative)
                             .account(account)
@@ -175,6 +179,7 @@ public class NanoAccountOperations {
                             .build();
                 case "send":
                     return NanoSendBlock.builder()
+                            .accountType(accountType)
                             .previous(previous)
                             .destination(destination)
                             .balance(balance)
@@ -186,6 +191,7 @@ public class NanoAccountOperations {
                             .build();
                 default:
                     return NanoStateBlock.builder()
+                            .accountType(accountType)
                             .account(account)
                             .previous(previous)
                             .representative(representative)

--- a/src/main/java/com/rotilho/jnano/client/block/NanoOpenBlock.java
+++ b/src/main/java/com/rotilho/jnano/client/block/NanoOpenBlock.java
@@ -1,5 +1,6 @@
 package com.rotilho.jnano.client.block;
 
+import com.rotilho.jnano.commons.NanoAccountType;
 import com.rotilho.jnano.commons.NanoBlocks;
 
 import lombok.Builder;
@@ -9,6 +10,8 @@ import lombok.Value;
 @Value
 @Builder
 public class NanoOpenBlock implements NanoBlock {
+    @NonNull
+    private NanoAccountType accountType;
     @NonNull
     private final String source;
     @NonNull
@@ -23,6 +26,6 @@ public class NanoOpenBlock implements NanoBlock {
 
     @Override
     public String getHash() {
-        return NanoBlocks.hashOpenBlock(source, representative, account);
+        return NanoBlocks.hashOpenBlock(accountType, source, representative, account);
     }
 }

--- a/src/main/java/com/rotilho/jnano/client/block/NanoSendBlock.java
+++ b/src/main/java/com/rotilho/jnano/client/block/NanoSendBlock.java
@@ -1,5 +1,6 @@
 package com.rotilho.jnano.client.block;
 
+import com.rotilho.jnano.commons.NanoAccountType;
 import com.rotilho.jnano.commons.NanoAmount;
 import com.rotilho.jnano.commons.NanoBlocks;
 
@@ -10,6 +11,8 @@ import lombok.Value;
 @Value
 @Builder
 public class NanoSendBlock implements NanoBlock {
+    @NonNull
+    private NanoAccountType accountType;
     @NonNull
     private final String previous;
     @NonNull
@@ -24,6 +27,6 @@ public class NanoSendBlock implements NanoBlock {
 
     @Override
     public String getHash() {
-        return NanoBlocks.hashSendBlock(previous, destination, balance.toRaw().toBigInteger());
+        return NanoBlocks.hashSendBlock(accountType, previous, destination, balance);
     }
 }

--- a/src/main/java/com/rotilho/jnano/client/block/NanoStateBlock.java
+++ b/src/main/java/com/rotilho/jnano/client/block/NanoStateBlock.java
@@ -1,5 +1,6 @@
 package com.rotilho.jnano.client.block;
 
+import com.rotilho.jnano.commons.NanoAccountType;
 import com.rotilho.jnano.commons.NanoAmount;
 import com.rotilho.jnano.commons.NanoBlocks;
 
@@ -10,6 +11,8 @@ import lombok.Value;
 @Value
 @Builder
 public class NanoStateBlock implements NanoBlock {
+    @NonNull
+    private NanoAccountType accountType;
     @NonNull
     private final String account;
     @NonNull
@@ -28,6 +31,6 @@ public class NanoStateBlock implements NanoBlock {
 
     @Override
     public String getHash() {
-        return NanoBlocks.hashStateBlock(account, previous, representative, balance.toRaw().toBigInteger(), link);
+        return NanoBlocks.hashStateBlock(accountType, account, previous, representative, balance, link);
     }
 }

--- a/src/main/java/com/rotilho/jnano/client/transaction/NanoTransactionOperations.java
+++ b/src/main/java/com/rotilho/jnano/client/transaction/NanoTransactionOperations.java
@@ -7,6 +7,7 @@ import com.rotilho.jnano.client.account.NanoAccountInfo;
 import com.rotilho.jnano.client.account.NanoAccountOperations;
 import com.rotilho.jnano.client.block.NanoStateBlock;
 import com.rotilho.jnano.client.work.NanoWorkOperations;
+import com.rotilho.jnano.commons.NanoAccountType;
 import com.rotilho.jnano.commons.NanoAccounts;
 import com.rotilho.jnano.commons.NanoAmount;
 import com.rotilho.jnano.commons.NanoHelper;
@@ -31,7 +32,8 @@ import static java.util.stream.Collectors.toList;
 @Builder
 @RequiredArgsConstructor(staticName = "of")
 public class NanoTransactionOperations {
-
+    @NonNull
+    private final NanoAccountType accountType;
     @NonNull
     private final NanoAPI api;
     @NonNull
@@ -52,6 +54,7 @@ public class NanoTransactionOperations {
 
         Map.Entry<String, NanoAmount> firstPending = pending.iterator().next();
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(accountType)
                 .account(account)
                 .previous("0000000000000000000000000000000000000000000000000000000000000000")
                 .representative(representative)
@@ -77,6 +80,7 @@ public class NanoTransactionOperations {
         NanoAccountInfo info = accountOperations.getInfoOrFail(account);
 
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(accountType)
                 .account(account)
                 .previous(info.getFrontier())
                 .representative(info.getRepresentative())
@@ -98,6 +102,7 @@ public class NanoTransactionOperations {
         NanoAmount balance = info.getBalance().subtract(amount);
 
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(accountType)
                 .account(sourceAccount)
                 .previous(previous)
                 .representative(info.getRepresentative())
@@ -112,6 +117,7 @@ public class NanoTransactionOperations {
         NanoAccountInfo info = accountOperations.getInfoOrFail(account);
 
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(accountType)
                 .account(account)
                 .previous(info.getFrontier())
                 .representative(representative)

--- a/src/test/java/com/rotilho/jnano/client/account/NanoAccountOperationsTest.java
+++ b/src/test/java/com/rotilho/jnano/client/account/NanoAccountOperationsTest.java
@@ -6,6 +6,7 @@ import com.rotilho.jnano.client.HttpMock;
 import com.rotilho.jnano.client.JSON;
 import com.rotilho.jnano.client.transaction.NanoTransaction;
 import com.rotilho.jnano.commons.NanoAmount;
+import com.rotilho.jnano.commons.NanoBaseAccountType;
 import com.rotilho.jnano.commons.NanoHelper;
 import com.rotilho.jnano.commons.NanoKeys;
 
@@ -33,7 +34,7 @@ public class NanoAccountOperationsTest {
 
     @Before
     public void setUp() {
-        operations = NanoAccountOperations.of(httpMock.getNanoAPI());
+        operations = NanoAccountOperations.of(NanoBaseAccountType.NANO, httpMock.getNanoAPI());
     }
 
     @Test

--- a/src/test/java/com/rotilho/jnano/client/block/NanoOpenBlockTest.java
+++ b/src/test/java/com/rotilho/jnano/client/block/NanoOpenBlockTest.java
@@ -1,5 +1,7 @@
 package com.rotilho.jnano.client.block;
 
+import com.rotilho.jnano.commons.NanoBaseAccountType;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -15,6 +17,7 @@ public class NanoOpenBlockTest {
 
         // when
         NanoOpenBlock block = NanoOpenBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .source(source)
                 .representative(representative)
                 .account(account)

--- a/src/test/java/com/rotilho/jnano/client/block/NanoSendBlockTest.java
+++ b/src/test/java/com/rotilho/jnano/client/block/NanoSendBlockTest.java
@@ -1,6 +1,7 @@
 package com.rotilho.jnano.client.block;
 
 import com.rotilho.jnano.commons.NanoAmount;
+import com.rotilho.jnano.commons.NanoBaseAccountType;
 
 import org.junit.Test;
 
@@ -17,6 +18,7 @@ public class NanoSendBlockTest {
 
         // when
         NanoSendBlock block = NanoSendBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .previous(previous)
                 .destination(destination)
                 .balance(balance)

--- a/src/test/java/com/rotilho/jnano/client/block/NanoStateBlockTest.java
+++ b/src/test/java/com/rotilho/jnano/client/block/NanoStateBlockTest.java
@@ -1,6 +1,7 @@
 package com.rotilho.jnano.client.block;
 
 import com.rotilho.jnano.commons.NanoAmount;
+import com.rotilho.jnano.commons.NanoBaseAccountType;
 
 import org.junit.Test;
 
@@ -19,6 +20,7 @@ public class NanoStateBlockTest {
 
         // when
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(account)
                 .previous(previous)
                 .representative(representative)
@@ -41,6 +43,7 @@ public class NanoStateBlockTest {
 
         // when
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(account)
                 .previous(previous)
                 .representative(representative)
@@ -63,6 +66,7 @@ public class NanoStateBlockTest {
 
         // when
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(account)
                 .previous(previous)
                 .representative(representative)
@@ -85,6 +89,7 @@ public class NanoStateBlockTest {
 
         // when
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(account)
                 .previous(previous)
                 .representative(representative)
@@ -107,6 +112,7 @@ public class NanoStateBlockTest {
 
         // when
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(account)
                 .previous(previous)
                 .representative(representative)

--- a/src/test/java/com/rotilho/jnano/client/transaction/NanoTransactionOperationsTest.java
+++ b/src/test/java/com/rotilho/jnano/client/transaction/NanoTransactionOperationsTest.java
@@ -8,12 +8,13 @@ import com.rotilho.jnano.client.transaction.NanoTransactionOperations.BlockHash;
 import com.rotilho.jnano.client.work.NanoWorkOperations;
 import com.rotilho.jnano.commons.NanoAccounts;
 import com.rotilho.jnano.commons.NanoAmount;
+import com.rotilho.jnano.commons.NanoBaseAccountType;
 import com.rotilho.jnano.commons.NanoHelper;
 import com.rotilho.jnano.commons.NanoKeys;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -52,8 +53,12 @@ public class NanoTransactionOperationsTest {
     @Mock
     private NanoWorkOperations workOperations;
 
-    @InjectMocks
     private NanoTransactionOperations operations;
+
+    @Before
+    public void setUp() {
+        operations = NanoTransactionOperations.of(NanoBaseAccountType.NANO, api, accountOperations, workOperations);
+    }
 
     @Test
     public void shouldOpen() {
@@ -192,6 +197,7 @@ public class NanoTransactionOperationsTest {
 
     private NanoTransaction<NanoStateBlock> createOpenTransaction() {
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(ACCOUNT)
                 .previous("0000000000000000000000000000000000000000000000000000000000000000")
                 .representative(REPRESENTATIVE)
@@ -208,6 +214,7 @@ public class NanoTransactionOperationsTest {
 
     private NanoTransaction<NanoStateBlock> createReceiveTransaction(NanoAmount amount) {
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(ACCOUNT)
                 .previous(FRONTIER)
                 .representative(REPRESENTATIVE)
@@ -223,6 +230,7 @@ public class NanoTransactionOperationsTest {
 
     private NanoTransaction<NanoStateBlock> createSendTransaction(NanoAmount amount) {
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(ACCOUNT)
                 .previous(FRONTIER)
                 .representative(REPRESENTATIVE)
@@ -239,6 +247,7 @@ public class NanoTransactionOperationsTest {
 
     private NanoTransaction<NanoStateBlock> createChangeTransaction(String representative) {
         NanoStateBlock block = NanoStateBlock.builder()
+                .accountType(NanoBaseAccountType.NANO)
                 .account(ACCOUNT)
                 .previous(FRONTIER)
                 .representative(representative)

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
It introduce a small break change while instantiating AccountOperations and TransactionOperations, now it requires to provide NanoAccountType (NANO or BANANO).